### PR TITLE
Fix init quickstart defaults

### DIFF
--- a/src/mithai/cli/doctor_cmd.py
+++ b/src/mithai/cli/doctor_cmd.py
@@ -8,7 +8,7 @@ import click
 
 from mithai import get_version_string
 from mithai.cli.style import banner_small, console, fail, kv, ok, section
-from mithai.core.config import load_config, get_skill_paths
+from mithai.core.config import load_config, get_skill_paths, get_memory_dir, get_state_dir
 from mithai.core.skill_loader import load_skills
 
 
@@ -196,27 +196,19 @@ def _check_skills(config: dict) -> int:
 
 
 def _configured_memory_dir(config: dict) -> Path | None:
-    learning = config.get("learning", {})
-    memory = learning.get("memory", {})
-    if not memory and "memory_dir" in learning:
-        return Path(learning["memory_dir"])
-
-    backend = memory.get("backend", "filesystem")
-    if backend != "filesystem":
+    memory_dir = get_memory_dir(config)
+    if memory_dir is None:
+        backend = config.get("learning", {}).get("memory", {}).get("backend", "filesystem")
         ok(f"Memory backend: [white]{backend}[/] (no local directory)")
-        return None
-
-    return Path(memory.get("filesystem", {}).get("path", "./memory"))
+    return memory_dir
 
 
 def _configured_state_dir(config: dict) -> Path | None:
-    state = config.get("state", {})
-    backend = state.get("backend", "filesystem")
-    if backend != "filesystem":
+    state_dir = get_state_dir(config)
+    if state_dir is None:
+        backend = config.get("state", {}).get("backend", "filesystem")
         ok(f"State backend: [white]{backend}[/] (no local directory)")
-        return None
-
-    return Path(state.get("filesystem", {}).get("path", "./.mithai/state"))
+    return state_dir
 
 
 def _check_directories(config: dict) -> int:

--- a/src/mithai/cli/doctor_cmd.py
+++ b/src/mithai/cli/doctor_cmd.py
@@ -12,9 +12,6 @@ from mithai.core.config import load_config, get_skill_paths
 from mithai.core.skill_loader import load_skills
 
 
-MITHAI_HOME = Path.home() / ".mithai"
-
-
 def _check_llm(config: dict) -> bool:
     """Check LLM connectivity."""
     llm = config.get("llm", {})
@@ -198,13 +195,42 @@ def _check_skills(config: dict) -> int:
         return 1
 
 
-def _check_directories() -> int:
+def _configured_memory_dir(config: dict) -> Path | None:
+    learning = config.get("learning", {})
+    memory = learning.get("memory", {})
+    if not memory and "memory_dir" in learning:
+        return Path(learning["memory_dir"])
+
+    backend = memory.get("backend", "filesystem")
+    if backend != "filesystem":
+        ok(f"Memory backend: [white]{backend}[/] (no local directory)")
+        return None
+
+    return Path(memory.get("filesystem", {}).get("path", "./memory"))
+
+
+def _configured_state_dir(config: dict) -> Path | None:
+    state = config.get("state", {})
+    backend = state.get("backend", "filesystem")
+    if backend != "filesystem":
+        ok(f"State backend: [white]{backend}[/] (no local directory)")
+        return None
+
+    return Path(state.get("filesystem", {}).get("path", "./.mithai/state"))
+
+
+def _check_directories(config: dict) -> int:
     """Check writable directories. Returns number of failures."""
     failures = 0
-    for name, path in [
-        ("Memory dir", MITHAI_HOME / "memory"),
-        ("State dir", MITHAI_HOME / "state"),
-    ]:
+    paths = []
+    memory_dir = _configured_memory_dir(config)
+    state_dir = _configured_state_dir(config)
+    if memory_dir is not None:
+        paths.append(("Memory dir", memory_dir))
+    if state_dir is not None:
+        paths.append(("State dir", state_dir))
+
+    for name, path in paths:
         if path.exists() and os.access(path, os.W_OK):
             ok(f"{name}: [muted]{path}[/]")
         elif path.exists():
@@ -234,11 +260,11 @@ def _check_mcp(config: dict) -> int:
 
 
 @click.command()
-@click.option("--config", "config_path", default=None,
-              help="Path to config.yaml (default: ~/.mithai/config.yaml)")
+@click.option("--config", "config_path", default="config.yaml",
+              help="Path to config.yaml")
 def doctor(config_path):
     """Run diagnostics — check config, connections, and dependencies."""
-    config_file = Path(config_path) if config_path else MITHAI_HOME / "config.yaml"
+    config_file = Path(config_path)
 
     banner_small("doctor")
     kv("Version", get_version_string(), indent=4)
@@ -298,7 +324,7 @@ def doctor(config_path):
 
     # Directories
     section("Filesystem")
-    issues += _check_directories()
+    issues += _check_directories(config)
 
     console.print()
     if issues == 0:

--- a/src/mithai/cli/init_cmd.py
+++ b/src/mithai/cli/init_cmd.py
@@ -10,6 +10,7 @@ from rich.prompt import Prompt, Confirm, IntPrompt
 from mithai.cli.style import (
     banner, console, fail, info, ok, step_header, summary_panel, warn,
 )
+from mithai.core.config import get_memory_dir, get_state_dir
 
 
 ENV_FILENAME = ".env"
@@ -85,17 +86,11 @@ def _ensure_gitignore_entry(target: Path, entry: str = ENV_FILENAME) -> None:
         gitignore_path.write_text(f"{entry}\n")
 
 
-def _configured_memory_dir(config: dict, default: Path) -> Path:
-    learning = config.get("learning", {})
-    memory = learning.get("memory", {})
-    if memory:
-        filesystem = memory.get("filesystem", {})
-        return Path(filesystem.get("path", default))
-    return Path(learning.get("memory_dir", default))
-
-
 @click.command()
-@click.option("--dir", "target_dir", default=None, help="Directory for config files (default: current directory)")
+@click.option(
+    "--dir", "target_dir", default=None,
+    help="Directory for config files (default: current directory)",
+)
 def init(target_dir):
     """Interactive setup wizard — configure adapters, LLM, skills, and more."""
     target = Path(target_dir) if target_dir else Path.cwd()
@@ -422,16 +417,19 @@ def init(target_dir):
     _ensure_gitignore_entry(target)
     ok(f"Updated [white]{target / '.gitignore'}[/] to ignore {ENV_FILENAME}")
 
-    # Create memory and state dirs
-    memory_dir = _configured_memory_dir(config, target / "memory")
-    memory_dir.mkdir(parents=True, exist_ok=True)
+    # Create memory and state dirs (skip non-filesystem backends, which have no local dir)
+    memory_dir = get_memory_dir(config, str(target / "memory"))
+    if memory_dir is not None:
+        memory_dir.mkdir(parents=True, exist_ok=True)
+        ok(f"Memory dir: [muted]{memory_dir}[/]")
 
-    state_dir = Path(config.get("state", {}).get("filesystem", {}).get("path", target / "state"))
-    state_dir.mkdir(parents=True, exist_ok=True)
+    state_dir = get_state_dir(config, str(target / ".mithai" / "state"))
+    if state_dir is not None:
+        state_dir.mkdir(parents=True, exist_ok=True)
+        ok(f"State dir: [muted]{state_dir}[/]")
+
     skills_dir = target / "skills"
     skills_dir.mkdir(parents=True, exist_ok=True)
-    ok(f"Memory dir: [muted]{memory_dir}[/]")
-    ok(f"State dir: [muted]{state_dir}[/]")
     ok(f"Skills dir: [muted]{skills_dir}[/]")
 
     # Summary

--- a/src/mithai/cli/init_cmd.py
+++ b/src/mithai/cli/init_cmd.py
@@ -12,7 +12,6 @@ from mithai.cli.style import (
 )
 
 
-MITHAI_HOME = Path.home() / ".mithai"
 ENV_FILENAME = ".env"
 
 
@@ -86,11 +85,20 @@ def _ensure_gitignore_entry(target: Path, entry: str = ENV_FILENAME) -> None:
         gitignore_path.write_text(f"{entry}\n")
 
 
+def _configured_memory_dir(config: dict, default: Path) -> Path:
+    learning = config.get("learning", {})
+    memory = learning.get("memory", {})
+    if memory:
+        filesystem = memory.get("filesystem", {})
+        return Path(filesystem.get("path", default))
+    return Path(learning.get("memory_dir", default))
+
+
 @click.command()
-@click.option("--dir", "target_dir", default=None, help="Directory for config files (default: ~/.mithai/)")
+@click.option("--dir", "target_dir", default=None, help="Directory for config files (default: current directory)")
 def init(target_dir):
     """Interactive setup wizard — configure adapters, LLM, skills, and more."""
-    target = Path(target_dir) if target_dir else MITHAI_HOME
+    target = Path(target_dir) if target_dir else Path.cwd()
     config_path = target / "config.yaml"
     env_path = target / ENV_FILENAME
 
@@ -372,11 +380,14 @@ def init(target_dir):
     })
     config.setdefault("state", {
         "backend": "filesystem",
-        "filesystem": {"path": str(target / "state")},
+        "filesystem": {"path": str(target / ".mithai" / "state")},
     })
     config.setdefault("learning", {
         "enabled": True,
-        "memory_dir": str(target / "memory"),
+        "memory": {
+            "backend": "filesystem",
+            "filesystem": {"path": str(target / "memory")},
+        },
         "reflection": True,
         "approval_auto_promote": 3,
     })
@@ -412,13 +423,16 @@ def init(target_dir):
     ok(f"Updated [white]{target / '.gitignore'}[/] to ignore {ENV_FILENAME}")
 
     # Create memory and state dirs
-    memory_dir = Path(config.get("learning", {}).get("memory_dir", target / "memory"))
+    memory_dir = _configured_memory_dir(config, target / "memory")
     memory_dir.mkdir(parents=True, exist_ok=True)
 
     state_dir = Path(config.get("state", {}).get("filesystem", {}).get("path", target / "state"))
     state_dir.mkdir(parents=True, exist_ok=True)
+    skills_dir = target / "skills"
+    skills_dir.mkdir(parents=True, exist_ok=True)
     ok(f"Memory dir: [muted]{memory_dir}[/]")
     ok(f"State dir: [muted]{state_dir}[/]")
+    ok(f"Skills dir: [muted]{skills_dir}[/]")
 
     # Summary
     all_skills = sorted(CORE_SKILLS | set(installed_skills))

--- a/src/mithai/core/config.py
+++ b/src/mithai/core/config.py
@@ -369,6 +369,35 @@ def get_skill_paths(config: dict) -> list[Path]:
     return result
 
 
+def get_memory_dir(config: dict, default: str = "./memory") -> Path | None:
+    """Resolve the filesystem memory directory from config.
+
+    Returns None when the memory backend is not filesystem (no local directory).
+    Honors the legacy flat ``learning.memory_dir`` key, preferring the canonical
+    ``learning.memory.filesystem.path`` shape when present. This is the single
+    source of truth for memory-path resolution shared by init/doctor and mirrors
+    the runtime reader in run_cmd._create_memory_backend.
+    """
+    learning = config.get("learning", {})
+    memory = learning.get("memory", {})
+    if not memory and "memory_dir" in learning:
+        return Path(learning["memory_dir"])
+    if memory.get("backend", "filesystem") != "filesystem":
+        return None
+    return Path(memory.get("filesystem", {}).get("path", default))
+
+
+def get_state_dir(config: dict, default: str = "./.mithai/state") -> Path | None:
+    """Resolve the filesystem state directory from config.
+
+    Returns None when the state backend is not filesystem (no local directory).
+    """
+    state = config.get("state", {})
+    if state.get("backend", "filesystem") != "filesystem":
+        return None
+    return Path(state.get("filesystem", {}).get("path", default))
+
+
 def get_mcp_config(config: dict) -> dict:
     """Get MCP server configurations. Returns empty dict if none configured."""
     return config.get("mcp_servers", {})

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -1,5 +1,6 @@
 """Tests for `mithai doctor` config path and filesystem checks."""
 
+import os
 from pathlib import Path
 
 from click.testing import CliRunner
@@ -65,3 +66,64 @@ def test_doctor_accepts_legacy_memory_dir(tmp_path):
     assert doctor_cmd._configured_memory_dir(
         {"learning": {"memory_dir": str(memory_dir)}}
     ) == memory_dir
+
+
+def test_doctor_resolves_new_filesystem_memory_shape():
+    config = {
+        "learning": {
+            "memory": {"backend": "filesystem", "filesystem": {"path": "/custom/mem"}},
+        },
+    }
+    assert doctor_cmd._configured_memory_dir(config) == Path("/custom/mem")
+    # Absent config falls back to the canonical default.
+    assert doctor_cmd._configured_memory_dir({}) == Path("./memory")
+
+
+def test_doctor_skips_non_filesystem_backends():
+    memory_none = doctor_cmd._configured_memory_dir(
+        {"learning": {"memory": {"backend": "redis"}}}
+    )
+    state_none = doctor_cmd._configured_state_dir({"state": {"backend": "memory"}})
+
+    assert memory_none is None
+    assert state_none is None
+
+
+def test_check_directories_reports_missing_dir(tmp_path):
+    config = {
+        "learning": {
+            "memory": {"backend": "filesystem", "filesystem": {"path": str(tmp_path / "nope")}},
+        },
+        "state": {
+            "backend": "filesystem",
+            "filesystem": {"path": str(tmp_path / ".mithai" / "state")},
+        },
+    }
+    (tmp_path / ".mithai" / "state").mkdir(parents=True)
+
+    # Missing memory dir -> one failure.
+    assert doctor_cmd._check_directories(config) == 1
+
+
+def test_check_directories_reports_non_writable_dir(tmp_path):
+    memory_dir = tmp_path / "memory"
+    memory_dir.mkdir()
+    memory_dir.chmod(0o500)  # exists but not writable
+    try:
+        config = {
+            "learning": {
+                "memory": {
+                    "backend": "filesystem",
+                    "filesystem": {"path": str(memory_dir)},
+                },
+            },
+        }
+        # State backend non-filesystem -> skipped, so only memory is checked.
+        config["state"] = {"backend": "memory"}
+
+        # A non-writable existing dir counts as a failure (skip if test runs as root).
+        if os.access(memory_dir, os.W_OK):
+            return
+        assert doctor_cmd._check_directories(config) == 1
+    finally:
+        memory_dir.chmod(0o700)

--- a/tests/test_doctor_cmd.py
+++ b/tests/test_doctor_cmd.py
@@ -1,0 +1,67 @@
+"""Tests for `mithai doctor` config path and filesystem checks."""
+
+from pathlib import Path
+
+from click.testing import CliRunner
+
+from mithai.cli import doctor_cmd
+
+
+def test_doctor_defaults_to_local_config(tmp_path, monkeypatch):
+    monkeypatch.setattr(doctor_cmd, "_check_llm", lambda _config: True)
+    monkeypatch.setattr(doctor_cmd, "_check_adapters", lambda _config: 0)
+    monkeypatch.setattr(doctor_cmd, "_check_mcp", lambda _config: 0)
+    monkeypatch.setattr(doctor_cmd, "_check_kubectl", lambda _config: 0)
+    monkeypatch.setattr(doctor_cmd, "_check_gh_cli", lambda: True)
+    monkeypatch.setattr(doctor_cmd, "_check_skills", lambda _config: 0)
+    monkeypatch.setattr(doctor_cmd, "_check_directories", lambda _config: 0)
+    monkeypatch.setattr(doctor_cmd, "load_skills", lambda _paths: {})
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        Path("config.yaml").write_text(
+            "adapter:\n"
+            "  types: [cli]\n"
+            "llm:\n"
+            "  provider: anthropic\n"
+            "  anthropic:\n"
+            "    api_key: ${ANTHROPIC_API_KEY}\n"
+        )
+        Path(".env").write_text("ANTHROPIC_API_KEY=sk-ant-test\n")
+
+        result = runner.invoke(doctor_cmd.doctor)
+
+    assert result.exit_code == 0, result.output
+    assert "Config" in result.output
+    assert "config.yaml" in result.output
+
+
+def test_doctor_checks_configured_filesystem_dirs(tmp_path):
+    memory_dir = tmp_path / "memory"
+    state_dir = tmp_path / ".mithai" / "state"
+    memory_dir.mkdir()
+    state_dir.mkdir(parents=True)
+
+    config = {
+        "learning": {
+            "memory": {
+                "backend": "filesystem",
+                "filesystem": {"path": str(memory_dir)},
+            },
+        },
+        "state": {
+            "backend": "filesystem",
+            "filesystem": {"path": str(state_dir)},
+        },
+    }
+
+    assert doctor_cmd._check_directories(config) == 0
+
+
+def test_doctor_accepts_legacy_memory_dir(tmp_path):
+    memory_dir = tmp_path / "legacy-memory"
+    memory_dir.mkdir()
+
+    assert doctor_cmd._configured_memory_dir(
+        {"learning": {"memory_dir": str(memory_dir)}}
+    ) == memory_dir

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -3,6 +3,7 @@
 import stat
 from pathlib import Path
 
+import yaml
 from click.testing import CliRunner
 
 from mithai.cli.init_cmd import init
@@ -46,6 +47,13 @@ def test_init_defaults_to_current_directory(tmp_path, monkeypatch):
         assert (cwd / "skills").is_dir()
         assert (cwd / "memory").is_dir()
         assert (cwd / ".mithai" / "state").is_dir()
+
+        # The written config must use the canonical filesystem shape the
+        # runtime reads (run_cmd._create_memory_backend / _create_state),
+        # so a regression back to the legacy flat shape is caught here.
+        cfg = yaml.safe_load((cwd / "config.yaml").read_text())
+        assert cfg["learning"]["memory"]["filesystem"]["path"] == str(cwd / "memory")
+        assert cfg["state"]["filesystem"]["path"] == str(cwd / ".mithai" / "state")
 
 
 def test_init_writes_dotenv_and_gitignore(tmp_path, monkeypatch):

--- a/tests/test_init_cmd.py
+++ b/tests/test_init_cmd.py
@@ -1,13 +1,14 @@
 """Tests for `mithai init` filesystem defaults."""
 
 import stat
+from pathlib import Path
 
 from click.testing import CliRunner
 
 from mithai.cli.init_cmd import init
 
 
-def test_init_writes_dotenv_and_gitignore(tmp_path, monkeypatch):
+def _patch_init_prompts(monkeypatch):
     import mithai.cli.init_cmd as init_mod
     import mithai.cli.skill_cmd as skill_mod
 
@@ -29,6 +30,27 @@ def test_init_writes_dotenv_and_gitignore(tmp_path, monkeypatch):
         staticmethod(lambda *_, default=False, **__: default),
     )
 
+
+def test_init_defaults_to_current_directory(tmp_path, monkeypatch):
+    _patch_init_prompts(monkeypatch)
+
+    runner = CliRunner()
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(init)
+        cwd = Path.cwd()
+
+        assert result.exit_code == 0, result.output
+        assert (cwd / "config.yaml").exists()
+        assert (cwd / ".env").exists()
+        assert (cwd / ".gitignore").exists()
+        assert (cwd / "skills").is_dir()
+        assert (cwd / "memory").is_dir()
+        assert (cwd / ".mithai" / "state").is_dir()
+
+
+def test_init_writes_dotenv_and_gitignore(tmp_path, monkeypatch):
+    _patch_init_prompts(monkeypatch)
+
     result = CliRunner().invoke(
         init,
         ["--dir", str(tmp_path)],
@@ -45,3 +67,4 @@ def test_init_writes_dotenv_and_gitignore(tmp_path, monkeypatch):
     gitignore_path = tmp_path / ".gitignore"
     assert gitignore_path.exists()
     assert ".env" in gitignore_path.read_text().splitlines()
+    assert (tmp_path / "skills").is_dir()


### PR DESCRIPTION
## What changed

- Make `mithai init` default to the current directory instead of `~/.mithai`, so the documented quickstart (`mithai init` then `mithai chat`) works without extra flags.
- Have `mithai init` create the project-local directories users expect: `skills/`, `memory/`, and `.mithai/state/`.
- Write the canonical filesystem memory config shape under `learning.memory.filesystem.path` while preserving legacy `learning.memory_dir` reads.
- Make `mithai doctor` default to local `config.yaml` and check the memory/state directories from the loaded config instead of hardcoded `~/.mithai` paths.
- Add regression coverage for project-local init defaults and doctor config/filesystem checks.

## Why

The public quickstart tells users to run `mithai init` and then `mithai chat`. Before this change, `init` wrote config into `~/.mithai`, while `chat` looked for `./config.yaml`, which made the first-run path fail unless users knew to pass `--dir` or `--config` manually.

## Validation

- `uv run pytest tests/test_init_cmd.py tests/test_doctor_cmd.py tests/test_config.py -q` — 30 passed.
- `uv run ruff check src/mithai/cli/init_cmd.py src/mithai/cli/doctor_cmd.py tests/test_init_cmd.py tests/test_doctor_cmd.py` — passed.