### PR TITLE
Set last9.io Homepage + convert PyPI publish to trusted publishing (OIDC)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
 mithai = "mithai.cli.main:cli"
 
 [project.urls]
-Homepage = "https://github.com/last9/mithai"
+Homepage = "https://last9.io"
 Repository = "https://github.com/last9/mithai"
 Issues = "https://github.com/last9/mithai/issues"
 


### PR DESCRIPTION
Point the PyPI Homepage URL at https://last9.io/ (mithai is a Last9 project); keep the GitHub repo as Repository/Issues. Metadata-only, no code changes. Surfaces on the PyPI project page once mithai is published.