### PR TITLE
ci: publish mithai to PyPI via trusted publishing (OIDC)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,17 +211,9 @@ jobs:
       name: pypi
       url: https://pypi.org/project/mithai/
     permissions:
+      id-token: write
       contents: read
     steps:
-      - name: Verify PYPI_API_TOKEN is configured
-        env:
-          PYPI_API_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
-        run: |
-          if [ -z "$PYPI_API_TOKEN" ]; then
-            echo "::error::PYPI_API_TOKEN secret is required to publish mithai to PyPI"
-            exit 1
-          fi
-
       - name: Download Python package artifact
         uses: actions/download-artifact@v4
         with:
@@ -230,8 +222,6 @@ jobs:
 
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   # ── Create GitHub Release ──
   release:


### PR DESCRIPTION
Follow-up to #4 (which merged the last9.io Homepage change). The trusted-publishing conversion was accidentally pushed to #4's branch after it merged, so it never landed on master — this PR applies it cleanly.

Converts the `publish-pypi` job in `release.yml` from an API token to OIDC trusted publishing (matches last9/gpu-telemetry):
- remove the "Verify PYPI_API_TOKEN" step and the `password: ${{ secrets.PYPI_API_TOKEN }}` line
- add `id-token: write` to the job permissions

No token/secret needed. The container-image publish to ghcr.io (`password: github.token`) is unrelated and untouched. Requires a PyPI pending publisher (project `mithai`, owner `last9`, repo `mithai`, workflow `release.yml`, environment `pypi`) before the first tagged release.